### PR TITLE
Deploy master branch to Heroku staging automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,3 +56,15 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
+
+      # Deploy
+      - add_ssh_keys:
+          fingerprints:
+            - "37:f2:e1:e5:bc:9a:6e:06:ba:17:35:4b:4d:6c:68:c4"
+      - deploy:
+          name: Deploy master to staging
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              .circleci/heroku_setup
+              .circleci/heroku_deploy
+            fi

--- a/.circleci/heroku_deploy
+++ b/.circleci/heroku_deploy
@@ -1,0 +1,10 @@
+#! /bin/bash -e
+
+if git remote | grep heroku > /dev/null; then
+  git fetch heroku
+  git push --force heroku $CIRCLE_SHA1:master
+  heroku run --exit-code rake db:migrate
+  heroku restart
+else
+  exit 0
+fi

--- a/.circleci/heroku_setup
+++ b/.circleci/heroku_setup
@@ -1,0 +1,21 @@
+#! /bin/bash -e
+
+app_name=majinhu-staging
+
+git remote add heroku https://git.heroku.com/$app_name.git
+wget https://cli-assets.heroku.com/branches/stable/heroku-linux-amd64.tar.gz
+mkdir -p /usr/local/lib /usr/local/bin
+sudo tar -xzf heroku-linux-amd64.tar.gz -C /usr/local/lib
+sudo ln -s /usr/local/lib/heroku/bin/heroku /usr/local/bin/heroku
+
+cat > ~/.netrc << EOF
+machine api.heroku.com
+  login $HEROKU_LOGIN
+  password $HEROKU_API_KEY
+machine git.heroku.com
+  login $HEROKU_LOGIN
+  password $HEROKU_API_KEY
+EOF
+
+# Add heroku.com to the list of known hosts
+ssh-keyscan -H heroku.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
Followed the [documentation](https://circleci.com/docs/2.0/deployment_integrations/#heroku) with some tweaks. This will automatically deploy to Heroku staging after a successful build on the master branch.